### PR TITLE
fix thumbnail-box

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -72,7 +72,7 @@ font-weight: 400;
 }
 
 .thumbnail-box{
-	height: 21rem;
+	height: auto;
 	background: #eee;
 	margin: 20px auto;    		
 	-webkit-transition: .2s ease-in-out;

--- a/css/style.css
+++ b/css/style.css
@@ -122,7 +122,7 @@ font-weight: 400;
 	width: 3.5rem;
 }
 .thumbnail-box{
-	height: 15rem;
+	height: auto;
 }
 .footer-logo{
 	width: 80%;


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。
  ・ Please specify related Issue ID.

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
- close #4 
レビューお願いします。

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- css/style.css 73行目で指定されているheightを21remからautoへ変更

## 📸 スクリーンショット / Screenshots
1080pのスクリーンでも枠内に収まるようになりました。
デベロッパーツールで各種デバイスでの確認は通りましたが、手動でブラウザの表示幅を600px前後にすると枠が崩れます。
![スクリーンショット 2020-03-14 18 19 28](https://user-images.githubusercontent.com/1632947/76679034-648a6700-6620-11ea-9976-a86c83a0b6fc.jpg)