### PR TITLE
リソースのURL変更 #50

### DIFF
--- a/content/100anniv/song.html
+++ b/content/100anniv/song.html
@@ -46,16 +46,16 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-					<a href="https://www.scout.or.jp/download/dist/centennial/song/piano.mp3" class="btn download-button disabled"><i class="material-icons left">file_download</i>ピアノ伴奏(mp3)</a><br>
-					<a href="https://www.scout.or.jp/download/dist/centennial/song/karaoke.mp3" class="btn download-button disabled"><i class="material-icons left">file_download</i>カラオケ(mp3)</a><br>
-					<a href="https://www.scout.or.jp/download/dist/centennial/song/piano_ceramony.mp3" class="btn download-button disabled"><i class="material-icons left">file_download</i>表彰用ピアノ(mp3)</a><br>
-					<a href="https://www.scout.or.jp/download/dist/centennial/song/scout_singing.mp3" class="btn download-button disabled"><i class="material-icons left">file_download</i>スカウト歌唱(mp3)</a><br>
-					<a href="https://www.scout.or.jp/download/dist/centennial/song/kurosawa_elm_singing.mp3" class="btn download-button disabled"><i class="material-icons left">file_download</i>黒沢尻北小学校(mp3)</a><br>
-					<a href="https://www.scout.or.jp/download/dist/centennial/song/lyrics_card.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>歌詞カード(pdf)</a><br>
-					<a href="https://www.scout.or.jp/download/dist/centennial/song/score.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>楽譜(pdf)</a><br>
-					<a href="https://www.scout.or.jp/download/dist/centennial/song/score_advice.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>歌唱アドバイス付き 楽譜(pdf)</a><br>
-					<a href="https://www.scout.or.jp/download/dist/centennial/song/piano_score.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ピアノ譜(pdf)</a><br>
-					<a href="https://www.scout.or.jp/download/dist/centennial/song/singing_movie.mp4" class="btn download-button disabled"><i class="material-icons left">file_download</i>合唱動画(mp4)</a><br>
+					<a href="https://prtool-download.scout.or.jp/dist/centennial/song/piano.mp3" class="btn download-button disabled"><i class="material-icons left">file_download</i>ピアノ伴奏(mp3)</a><br>
+					<a href="https://prtool-download.scout.or.jp/dist/centennial/song/karaoke.mp3" class="btn download-button disabled"><i class="material-icons left">file_download</i>カラオケ(mp3)</a><br>
+					<a href="https://prtool-download.scout.or.jp/dist/centennial/song/piano_ceramony.mp3" class="btn download-button disabled"><i class="material-icons left">file_download</i>表彰用ピアノ(mp3)</a><br>
+					<a href="https://prtool-download.scout.or.jp/dist/centennial/song/scout_singing.mp3" class="btn download-button disabled"><i class="material-icons left">file_download</i>スカウト歌唱(mp3)</a><br>
+					<a href="https://prtool-download.scout.or.jp/dist/centennial/song/kurosawa_elm_singing.mp3" class="btn download-button disabled"><i class="material-icons left">file_download</i>黒沢尻北小学校(mp3)</a><br>
+					<a href="https://prtool-download.scout.or.jp/dist/centennial/song/lyrics_card.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>歌詞カード(pdf)</a><br>
+					<a href="https://prtool-download.scout.or.jp/dist/centennial/song/score.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>楽譜(pdf)</a><br>
+					<a href="https://prtool-download.scout.or.jp/dist/centennial/song/score_advice.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>歌唱アドバイス付き 楽譜(pdf)</a><br>
+					<a href="https://prtool-download.scout.or.jp/dist/centennial/song/piano_score.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ピアノ譜(pdf)</a><br>
+					<a href="https://prtool-download.scout.or.jp/dist/centennial/song/singing_movie.mp4" class="btn download-button disabled"><i class="material-icons left">file_download</i>合唱動画(mp4)</a><br>
 					<br />
 		      	</div>
 	      	</div>

--- a/content/booklet/dantai.html
+++ b/content/booklet/dantai.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/booklet/organisation-brochure-2021.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/booklet/organisation-brochure-2021.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/booklet/leaf_ad.html
+++ b/content/booklet/leaf_ad.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/booklet/leaflet-parent.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/booklet/leaflet-parent.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/booklet/leaf_ad_ppt.html
+++ b/content/booklet/leaf_ad_ppt.html
@@ -45,11 +45,11 @@
 		        	<img class="responsive-img" src="img/leaf_ad.jpg">
 		      	<div>
 		      	「お問い合わせ」先を編集して使用する場合はこちらをご活用下さい。<br>
-					<a href="https://www.scout.or.jp/download/dist/booklet/how_to_edit_and_print.pdf">編集して使用する場合の保存方法</a><br>
+					<a href="https://prtool-download.scout.or.jp/dist/booklet/how_to_edit_and_print.pdf">編集して使用する場合の保存方法</a><br>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a>
 					</label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/booklet/leaflet-parent.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/booklet/leaflet-parent.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 		      	</div>
 	      	</div>
 		</div>

--- a/content/booklet/leaf_ki.html
+++ b/content/booklet/leaf_ki.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/booklet/leaflet-youth.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/booklet/leaflet-youth.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/booklet/leaf_ki_ppt.html
+++ b/content/booklet/leaf_ki_ppt.html
@@ -45,10 +45,10 @@
 		        	<img class="responsive-img" src="img/leaf_ki.jpg">
 		      	<div>
 		      	「お問い合わせ」先を編集して使用する場合はこちらをご活用下さい。<br>
-					<a href="https://www.scout.or.jp/download/dist/booklet/how_to_edit_and_print.pdf">編集して使用する場合の保存方法</a><br>
+					<a href="https://prtool-download.scout.or.jp/dist/booklet/how_to_edit_and_print.pdf">編集して使用する場合の保存方法</a><br>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/booklet/leaflet-youth.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/booklet/leaflet-youth.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/booklet/qa.html
+++ b/content/booklet/qa.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/booklet/qa-2018.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/booklet/qa-2018.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/comlogo/bc1.html
+++ b/content/comlogo/bc1.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/namecard1.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/namecard1.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/comlogo/bc2.html
+++ b/content/comlogo/bc2.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/namecard2.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/namecard2.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/comlogo/bc3.html
+++ b/content/comlogo/bc3.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/namecard3.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/namecard3.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/comlogo/comlogo.html
+++ b/content/comlogo/comlogo.html
@@ -47,16 +47,16 @@
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
 		      		<div class="col s12 m6 l6 xl6" style="text-align: center;">
-			      		<a href="https://www.scout.or.jp/download/dist/cmlogo/cmlogo-rgb-l.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>電子用　大</a><br />
-			      		<a href="https://www.scout.or.jp/download/dist/cmlogo/cmlogo-rgb-m.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>電子用　中</a><br />
-			      		<a href="https://www.scout.or.jp/download/dist/cmlogo/cmlogo-rgb-s.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>電子用　小</a><br />
+			      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/cmlogo-rgb-l.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>電子用　大</a><br />
+			      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/cmlogo-rgb-m.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>電子用　中</a><br />
+			      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/cmlogo-rgb-s.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>電子用　小</a><br />
 		      		</div>
 		      		<div class="col s12 m6 l6 xl6" style="text-align: center;">
-			      		<a href="https://www.scout.or.jp/download/dist/cmlogo/cmlogo-cmyk-l.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>印刷用　大</a><br />
-			      		<a href="https://www.scout.or.jp/download/dist/cmlogo/cmlogo-cmyk-m.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>印刷用　中</a><br />
-			      		<a href="https://www.scout.or.jp/download/dist/cmlogo/cmlogo-cmyk-s.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>印刷用　小</a><br />
+			      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/cmlogo-cmyk-l.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>印刷用　大</a><br />
+			      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/cmlogo-cmyk-m.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>印刷用　中</a><br />
+			      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/cmlogo-cmyk-s.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>印刷用　小</a><br />
 		      		</div>
-			      	<a href="https://www.scout.or.jp/download/dist/cmlogo/cmlogo.ai" class="btn download-button disabled"><i class="material-icons left">file_download</i>Adobe illustrator用</a><br />
+			      	<a href="https://prtool-download.scout.or.jp/dist/cmlogo/cmlogo.ai" class="btn download-button disabled"><i class="material-icons left">file_download</i>Adobe illustrator用</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/comlogo/comlogo2.html
+++ b/content/comlogo/comlogo2.html
@@ -47,16 +47,16 @@
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
 		      		<div class="col s12 m6 l6 xl6" style="text-align: center;">
-			      		<a href="https://www.scout.or.jp/download/dist/cmlogo/cmlogo2-rgb-l.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>電子用　大</a><br />
-			      		<a href="https://www.scout.or.jp/download/dist/cmlogo/cmlogo2-rgb-m.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>電子用　中</a><br />
-			      		<a href="https://www.scout.or.jp/download/dist/cmlogo/cmlogo2-rgb-s.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>電子用　小</a><br />
+			      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/cmlogo2-rgb-l.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>電子用　大</a><br />
+			      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/cmlogo2-rgb-m.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>電子用　中</a><br />
+			      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/cmlogo2-rgb-s.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>電子用　小</a><br />
 		      		</div>
 		      		<div class="col s12 m6 l6 xl6" style="text-align: center;">
-			      		<a href="https://www.scout.or.jp/download/dist/cmlogo/cmlogo2-cmyk-l.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>印刷用　大</a><br />
-			      		<a href="https://www.scout.or.jp/download/dist/cmlogo/cmlogo2-cmyk-m.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>印刷用　中</a><br />
-			      		<a href="https://www.scout.or.jp/download/dist/cmlogo/cmlogo2-cmyk-s.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>印刷用　小</a><br />
+			      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/cmlogo2-cmyk-l.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>印刷用　大</a><br />
+			      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/cmlogo2-cmyk-m.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>印刷用　中</a><br />
+			      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/cmlogo2-cmyk-s.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>印刷用　小</a><br />
 		      		</div>
-			      	<a href="https://www.scout.or.jp/download/dist/cmlogo/cmlogo2.ai" class="btn download-button disabled"><i class="material-icons left">file_download</i>Adobe illustrator用</a><br />
+			      	<a href="https://prtool-download.scout.or.jp/dist/cmlogo/cmlogo2.ai" class="btn download-button disabled"><i class="material-icons left">file_download</i>Adobe illustrator用</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/comlogo/lh.html
+++ b/content/comlogo/lh.html
@@ -47,7 +47,7 @@
 
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/letterhead.docx" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/letterhead.docx" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/comlogo/pp1.html
+++ b/content/comlogo/pp1.html
@@ -46,8 +46,8 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/slide1-4x3.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>4:3</a><br />
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/slide1-16x9.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>16:9</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/slide1-4x3.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>4:3</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/slide1-16x9.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>16:9</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/comlogo/pp2.html
+++ b/content/comlogo/pp2.html
@@ -46,8 +46,8 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/slide2-4x3.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>4:3</a><br />
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/slide2-16x9.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>16:9</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/slide2-4x3.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>4:3</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/slide2-16x9.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>16:9</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/comlogo/wp1.html
+++ b/content/comlogo/wp1.html
@@ -46,9 +46,9 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/wallpaper1-1600x1200-4x3.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>1600×1200(4:3)</a><br />
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/wallpaper1-1920x1080-16x9.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>1920×1080(16:9)</a><br />
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/wallpaper1-2880x1800-16x10.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>2880×1800(16:10)</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/wallpaper1-1600x1200-4x3.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>1600×1200(4:3)</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/wallpaper1-1920x1080-16x9.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>1920×1080(16:9)</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/wallpaper1-2880x1800-16x10.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>2880×1800(16:10)</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/comlogo/wp2.html
+++ b/content/comlogo/wp2.html
@@ -46,9 +46,9 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/wallpaper2-1600x1200-4x3.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>1600×1200(4:3)</a><br />
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/wallpaper2-1920x1080-16x9.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>1920×1080(16:9)</a><br />
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/wallpaper2-2880x1800-16x10.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>2880×1800(16:10)</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/wallpaper2-1600x1200-4x3.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>1600×1200(4:3)</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/wallpaper2-1920x1080-16x9.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>1920×1080(16:9)</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/wallpaper2-2880x1800-16x10.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>2880×1800(16:10)</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/comlogo/wp3.html
+++ b/content/comlogo/wp3.html
@@ -46,9 +46,9 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/wallpaper3-1600x1200-4x3.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>1600×1200(4:3)</a><br />
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/wallpaper3-1920x1080-16x9.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>1920×1080(16:9)</a><br />
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/wallpaper3-2880x1800-16x10.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>2880×1800(16:10)</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/wallpaper3-1600x1200-4x3.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>1600×1200(4:3)</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/wallpaper3-1920x1080-16x9.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>1920×1080(16:9)</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/wallpaper3-2880x1800-16x10.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>2880×1800(16:10)</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/comlogo/wp4.html
+++ b/content/comlogo/wp4.html
@@ -46,10 +46,10 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/wallpaper-android-9x16.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>Android用(9:16)</a><br />
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/wallpaper-iphone5-SE.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>iPhone5,SE用</a><br />
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/wallpaper-iphone6-7.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>iPhone6,7用</a><br />
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/wallpaper-iphone6plus-7plus.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>iPhone6Plus,7Plus用</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/wallpaper-android-9x16.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>Android用(9:16)</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/wallpaper-iphone5-SE.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>iPhone5,SE用</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/wallpaper-iphone6-7.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>iPhone6,7用</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/wallpaper-iphone6plus-7plus.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>iPhone6Plus,7Plus用</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/comlogo/wp5.html
+++ b/content/comlogo/wp5.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/wallpaper4.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/wallpaper4.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/karuta/karuta.html
+++ b/content/karuta/karuta.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/karuta/karuta.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/karuta/karuta.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/karuta/karuta_temp1.html
+++ b/content/karuta/karuta_temp1.html
@@ -46,8 +46,8 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/karuta/karuta-template-sheet.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>パワーポイント</a><br />
-		      		<a href="https://www.scout.or.jp/download/dist/karuta/karuta-template-sheet.zip" class="btn download-button disabled"><i class="material-icons left">file_download</i>画像</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/karuta/karuta-template-sheet.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>パワーポイント</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/karuta/karuta-template-sheet.zip" class="btn download-button disabled"><i class="material-icons left">file_download</i>画像</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/karuta/karuta_temp2.html
+++ b/content/karuta/karuta_temp2.html
@@ -46,8 +46,8 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/karuta/karuta-template-card.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>パワーポイント</a><br />
-		      		<a href="https://www.scout.or.jp/download/dist/karuta/karuta-template-card.zip" class="btn download-button disabled"><i class="material-icons left">file_download</i>画像</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/karuta/karuta-template-card.pptx" class="btn download-button disabled"><i class="material-icons left">file_download</i>パワーポイント</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/karuta/karuta-template-card.zip" class="btn download-button disabled"><i class="material-icons left">file_download</i>画像</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/ouchi/circle.html
+++ b/content/ouchi/circle.html
@@ -49,7 +49,7 @@
 						<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
 						<div class="row">
 							<!-- <div class="col s12 m6 l6 xl6" style="text-align: center;"> -->
-							<br><a href="https://www.scout.or.jp/download/dist/cmlogo/ouchi_scouting_circle.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a>
+							<br><a href="https://prtool-download.scout.or.jp/dist/cmlogo/ouchi_scouting_circle.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a>
 						</div>
 					</div>
 

--- a/content/ouchi/frame.html
+++ b/content/ouchi/frame.html
@@ -49,7 +49,7 @@
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
 					<div class="row">
 						<!-- <div class="col s12 m6 l6 xl6" style="text-align: center;"> -->
-						<a href="https://www.scout.or.jp/download/dist/cmlogo/ouchi_scouting_flame.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+						<a href="https://prtool-download.scout.or.jp/dist/cmlogo/ouchi_scouting_flame.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 					</div>
 				</div>
 

--- a/content/ouchi/main.html
+++ b/content/ouchi/main.html
@@ -49,8 +49,8 @@
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
 					<div class="row">
 						<!-- <div class="col s12 m6 l6 xl6" style="text-align: center;"> -->
-							<a href="https://www.scout.or.jp/download/dist/cmlogo/ouchi_scouting_t.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>メインロゴ(透過)</a><br>
-							<a href="https://www.scout.or.jp/download/dist/cmlogo/ouchi_scouting_w.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>メインロゴ(白背景)</a>
+							<a href="https://prtool-download.scout.or.jp/dist/cmlogo/ouchi_scouting_t.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>メインロゴ(透過)</a><br>
+							<a href="https://prtool-download.scout.or.jp/dist/cmlogo/ouchi_scouting_w.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>メインロゴ(白背景)</a>
 						<!-- </div> -->
 					</div>
 

--- a/content/ouchi/main_com.html
+++ b/content/ouchi/main_com.html
@@ -48,8 +48,8 @@
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
 					<div class="row">
-							<a href="https://www.scout.or.jp/download/dist/cmlogo/ouchi_scouting_cmologo_t.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>CMロゴ(透過)</a><br />
-							<a href="https://www.scout.or.jp/download/dist/cmlogo/ouchi_scouting_cmologo_w.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>CMロゴ(白背景)</a><br />
+							<a href="https://prtool-download.scout.or.jp/dist/cmlogo/ouchi_scouting_cmologo_t.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>CMロゴ(透過)</a><br />
+							<a href="https://prtool-download.scout.or.jp/dist/cmlogo/ouchi_scouting_cmologo_w.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>CMロゴ(白背景)</a><br />
 						</div>
 					</div>
 

--- a/content/ouchi/square.html
+++ b/content/ouchi/square.html
@@ -49,7 +49,7 @@
 						<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
 						<div class="row">
 							<!-- <div class="col s12 m6 l6 xl6" style="text-align: center;"> -->
-							<a href="https://www.scout.or.jp/download/dist/cmlogo/ouchi_scouting_spuare.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a>
+							<a href="https://prtool-download.scout.or.jp/dist/cmlogo/ouchi_scouting_spuare.png" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a>
 						</div>
 					</div>
 

--- a/content/ouchi/wp-ouchiscouting.html
+++ b/content/ouchi/wp-ouchiscouting.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/cmlogo/ouchi_bg.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/cmlogo/ouchi_bg.jpg" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/poster/poster-movie.html
+++ b/content/poster/poster-movie.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/poster/saj-movie.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/poster/saj-movie.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/poster/poster-rock.html
+++ b/content/poster/poster-rock.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/poster/saj-music.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/poster/saj-music.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/poster/poster-space.html
+++ b/content/poster/poster-space.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/poster/saj-astronaut.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/poster/saj-astronaut.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/poster/poster1.html
+++ b/content/poster/poster1.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/poster/saj-2018.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/poster/saj-2018.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/poster/poster2.html
+++ b/content/poster/poster2.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/poster/osaka1.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/poster/osaka1.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/poster/poster3.html
+++ b/content/poster/poster3.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/poster/osaka2.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/poster/osaka2.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/poster/poster4.html
+++ b/content/poster/poster4.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/poster/osaka3.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/poster/osaka3.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/poster/poster5.html
+++ b/content/poster/poster5.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/poster/osaka4.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/poster/osaka4.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/poster/saj-poster-tearai.html
+++ b/content/poster/saj-poster-tearai.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/poster/saj-handwash.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/poster/saj-handwash.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/poster/saj-poster1.html
+++ b/content/poster/saj-poster1.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/poster/saj-2019.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/poster/saj-2019.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/content/poster/saj-poster2.html
+++ b/content/poster/saj-poster2.html
@@ -46,7 +46,7 @@
 		      	<div>
 					<input type="checkbox" id="cb-agree" autocomplete="off">
 					<label for="cb-agree"><a href="../../about.html">「各種使用に関して」</a></label>に同意します<br>
-		      		<a href="https://www.scout.or.jp/download/dist/poster/saj-2019-2.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
+		      		<a href="https://prtool-download.scout.or.jp/dist/poster/saj-2019-2.pdf" class="btn download-button disabled"><i class="material-icons left">file_download</i>ダウンロード</a><br />
 
 		      	</div>
 	      	</div>

--- a/index.html
+++ b/index.html
@@ -531,8 +531,8 @@
 			</div>
 
 			<div class="social-share center">
-				<a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-url="https://www.scout.or.jp/download/" data-lang="ja" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-				<iframe src="https://www.facebook.com/plugins/share_button.php?href=https%3A%2F%2Fwww.scout.or.jp%2Fdownload%2F&layout=button_count&size=small&mobile_iframe=true&width=72&height=20&appId" width=100 height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true"></iframe>
+				<a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-url="https://prtool-download.scout.or.jp/" data-lang="ja" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+				<iframe src="https://www.facebook.com/plugins/share_button.php?href=https%3A%2F%2Fprtool-download.scout.or.jp%2F&layout=button_count&size=small&mobile_iframe=true&width=72&height=20&appId" width=100 height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true"></iframe>
 			</div>
 
 		</div>


### PR DESCRIPTION
change linked url due to change in hosting url of this webpage

## 📝 関連issue / Related Issues
- close #50 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- ダウンロードするリソースのリンク先URLを http://www.scout.or.jp/download/ から http://prtool-download.scout.or.jp/ へ変更
- fb tw シェアボタンでシェアするURLも同じく変更

## 📸 スクリーンショット / Screenshots
n/a